### PR TITLE
Fix player passing through platform after jumping (Closes #1)

### DIFF
--- a/src/GameControllers/PlayerController.js
+++ b/src/GameControllers/PlayerController.js
@@ -100,7 +100,7 @@ class PlayerController extends GameObject{
         // this.player.body.moveWithCollisions(this.player.body.position.addInPlace(this.gravity).subtractInPlace(Vector3.Up().scale(PlayerController.PLAYER_SPEED * this.deltaTime)));
         //  this.player.body.moveWithCollisions(this.player.body.frontVector.addInPlace(this.gravity));
 
-        if (this.isGrounded()) {
+        /* if (this.isGrounded()) {
             this.gravity.y = 0;
             console.log("ground")
             // this.lastGroundPos.copyFrom(this.player.body.position);
@@ -114,6 +114,23 @@ class PlayerController extends GameObject{
                 this.player.body.position.addInPlace(vel)
                 this.win = true
             }
+            this.lastPlatform.metadata.lastPosition = this.lastPlatform.position.clone()
+        } */
+
+        if (this.isGrounded()) {
+            this.gravity.y = 0;
+            console.log("ground")
+            this.grounded = true;
+            this.jumpCount = 1;
+            this.isJumping = false;
+            this.isFalling = false;
+
+            // Controlla se il player interseca la piattaforma
+            if (this.player.body.intersectsMesh(this.lastPlatform, true)) {
+                // Sposta il player leggermente verso l'alto
+                this.player.body.position.y += 0.1; // Regola il valore in base alle tue esigenze
+            }
+
             this.lastPlatform.metadata.lastPosition = this.lastPlatform.position.clone()
         }
 


### PR DESCRIPTION
Inside the if (this.isGrounded()) block, after setting the necessary flags and variables when the player is grounded, we added an additional check.
We use this.player.body.intersectsMesh(this.lastPlatform, true) to check if the player's body intersects with the last platform they landed on.
If there is an intersection, we slightly move the player upwards by adding a small value (in this case, 0.1) to the y component of the player's body position. This helps to prevent the player from passing through the platform.
The value 0.1 is used as an example, and you can adjust it based on your specific game requirements and the scale of your objects.
Finally, we update the lastPosition of the platform in the metadata to keep track of its current position for future reference.
This modification ensures that when the player lands on a platform after jumping, if there is any intersection between the player and the platform, the player is slightly pushed upwards to avoid passing through the platform.